### PR TITLE
convert to url path instead of org

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ public key, suitable for use in tools like [jwt.io](https://jwt.io)
 Here is an example of using this tool to get the PEM encoded public
 keys for the "example.okta.com" Okta org:
 
-    ./jwks_to_pem.py --org example.okta.com
+    ./jwks_to_pem.py --url example.okta.com/.well-known/jwks.json
 
-    Fetching JWKS from example.okta.com
+    Fetching JWKS from example.okta.com/.well-known/jwks.json
     PEM for KID 're7eOFV6SiygSbCyYHGGdERFCJ_EoNpi9Duv0FIxllo'
     -----BEGIN PUBLIC KEY-----
     MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgVdVgO4RogxtWt4XN2vO
@@ -63,7 +63,7 @@ package manager on GNU/Linux or Macintosh OS X systems:
         cd okta-jwks-to-pem
 4.  Run the script:
     
-        ./jwks-to-pem.py --org example.okta.org
+        ./jwks-to-pem.py --url example.okta.org
 
 # How it works
 
@@ -97,7 +97,7 @@ We cover the rest of the script below.
 
 First, we import the libraries that we'll need:
 
--   `argparse`: For handling the `--org=` command line argument and giving
+-   `argparse`: For handling the `--url=` command line argument and giving
     help when it isn't present.
 -   `base64`, `six`, `struct`: Used to properly decode the Base64url encoded modulus
     and exponent.
@@ -116,15 +116,15 @@ Here is how we import the dependencies listed above:
     from cryptography.hazmat.primitives import serialization
     import requests
 
-Next, we set up `ArgumentParser` to handle the `--org` command line
+Next, we set up `ArgumentParser` to handle the `--url` command line
 argument. The `required=true` option will cause `ArgumentParser` to give
-help text if the `--org` argument isn't present.
+help text if the `--url` argument isn't present.
 
     arg_parser = argparse.ArgumentParser(
         description='JWK to PEM conversion tool')
-    arg_parser.add_argument('--org',
-                            dest='org',
-                            help='Domain for Okta org',
+    arg_parser.add_argument('--url',
+                            dest='url',
+                            help='URL to jwks json object',
                             required=True)
     args = arg_parser.parse_args()
 

--- a/README.org
+++ b/README.org
@@ -22,7 +22,7 @@
   keys for the "example.okta.com" Okta org:
 
   #+BEGIN_SRC sh :results code
-    ./jwks_to_pem.py --org example.okta.com
+    ./jwks_to_pem.py --url example.okta.com
   #+END_SRC
 
   #+BEGIN_SRC sh
@@ -86,7 +86,7 @@
      #+END_SRC
   4. Run the script:
      #+BEGIN_SRC sh
-     ./jwks-to-pem.py --org example.okta.org
+     ./jwks-to-pem.py --url example.okta.org
      #+END_SRC
 * How it works
   The most important part of this code is the conversion of RSA public
@@ -123,7 +123,7 @@
   We cover the rest of the script below.
 
   First, we import the libraries that we'll need:
-  - =argparse=: For handling the =--org== command line argument and giving
+  - =argparse=: For handling the =--url== command line argument and giving
     help when it isn't present.
   - =base64=, =six=, =struct=: Used to properly decode the Base64url encoded modulus
     and exponent.
@@ -144,15 +144,15 @@
     import requests
   #+END_SRC
 
-  Next, we set up =ArgumentParser= to handle the =--org= command line
+  Next, we set up =ArgumentParser= to handle the =--url= command line
   argument. The =required=true= option will cause =ArgumentParser= to give
-  help text if the =--org= argument isn't present.
+  help text if the =--url= argument isn't present.
 
   #+NAME: parse-arguments
   #+BEGIN_SRC python
     arg_parser = argparse.ArgumentParser(
         description='JWK to PEM conversion tool')
-    arg_parser.add_argument('--org',
+    arg_parser.add_argument('--url',
                             dest='org',
                             help='Domain for Okta org',
                             required=True)

--- a/jwks_to_pem.py
+++ b/jwks_to_pem.py
@@ -13,9 +13,9 @@ import requests
 
 arg_parser = argparse.ArgumentParser(
     description='JWK to PEM conversion tool')
-arg_parser.add_argument('--org',
-                        dest='org',
-                        help='Domain for Okta org',
+arg_parser.add_argument('--url',
+                        dest='url',
+                        help='URL to JWKS json object',
                         required=True)
 args = arg_parser.parse_args()
 
@@ -32,8 +32,8 @@ def base64_to_long(data):
     return intarr2long(struct.unpack('%sB' % len(_d), _d))
 
 
-print("Fetching JWKS from {}".format(args.org))
-r = requests.get("https://{}/oauth2/v1/keys".format(args.org))
+print("Fetching JWKS from {}".format(args.url))
+r = requests.get(args.url)
 jwks = r.json()
 
 for jwk in jwks['keys']:


### PR DESCRIPTION
Allows it to be usable in other places other than just okta.